### PR TITLE
POC window position setting

### DIFF
--- a/Wholist/Configuration/PluginConfiguration.cs
+++ b/Wholist/Configuration/PluginConfiguration.cs
@@ -85,6 +85,17 @@ namespace Wholist.Configuration
             ///     Whether or not to hide most elements from the window.
             /// </summary>
             public bool MinimalMode;
+
+            /// <summary>
+            ///     Whether or not to use a specified window position.
+            /// </summary>
+            public bool SetWindowPosition;
+
+            /// <summary>
+            ///   The specified window position to use if <see cref="SetWindowPosition"/> is true.
+            /// </summary>
+            public int WindowPositionX;
+            public int WindowPositionY;
         }
 
         /// <summary>

--- a/Wholist/Resources/Localization/Strings.resx
+++ b/Wholist/Resources/Localization/Strings.resx
@@ -92,6 +92,15 @@
   <data name="UserInterface_Settings_NearbyPlayers_LockPosition" xml:space="preserve">
     <value>Disable window moving</value>
   </data>
+  <data name="UserInterface_Settings_NearbyPlayers_SpecifiedPosition" xml:space="preserve">
+    <value>Specify persistent window position</value>
+  </data>
+  <data name="UserInterface_Settings_NearbyPlayers_WindowPositionX" xml:space="preserve">
+    <value>Set X position window</value>
+  </data>
+  <data name="UserInterface_Settings_NearbyPlayers_WindowPositionY" xml:space="preserve">
+    <value>Set Y position window</value>
+  </data>
   <data name="UserInterface_Settings_NearbyPlayers_LockSize" xml:space="preserve">
     <value>Disable window resizing</value>
   </data>
@@ -106,6 +115,18 @@
   </data>
   <data name="UserInterface_Settings_NearbyPlayers_LockPosition_Description" xml:space="preserve">
     <value>Prevent the window from being moved.</value>
+  </data>
+  <data name="UserInterface_Settings_NearbyPlayers_SpecifiedPosition_Description"
+        xml:space="preserve">
+    <value>Always draw the window in a specified place</value>
+  </data>
+  <data name="UserInterface_Settings_NearbyPlayers_WindowPositionX_Description"
+        xml:space="preserve">
+    <value>The horizontal position the top left of the window should display at.</value>
+  </data>
+  <data name="UserInterface_Settings_NearbyPlayers_WindowPositionY_Description"
+        xml:space="preserve">
+    <value>The vertical position the top left of the window should display at.</value>
   </data>
   <data name="UserInterface_Settings_NearbyPlayers_LockSize_Description" xml:space="preserve">
     <value>Prevent the window from being resized.</value>

--- a/Wholist/UserInterface/Windows/NearbyPlayers/NearbyPlayers.window.cs
+++ b/Wholist/UserInterface/Windows/NearbyPlayers/NearbyPlayers.window.cs
@@ -9,6 +9,7 @@ using Sirensong.UserInterface;
 using Wholist.Common;
 using Wholist.DataStructures;
 using Wholist.Resources.Localization;
+using Wholist.UserInterface.Windows.Settings;
 
 namespace Wholist.UserInterface.Windows.NearbyPlayers
 {
@@ -24,6 +25,16 @@ namespace Wholist.UserInterface.Windows.NearbyPlayers
         {
             this.Size = new Vector2(450, 400);
             this.SizeCondition = ImGuiCond.FirstUseEver;
+
+            // Set the window position if specified
+            if (NearbyPlayersLogic.Configuration.NearbyPlayers.SetWindowPosition)
+            {
+                this.Position = new Vector2(
+                    NearbyPlayersLogic.Configuration.NearbyPlayers.WindowPositionX,
+                    NearbyPlayersLogic.Configuration.NearbyPlayers.WindowPositionY
+                );
+                this.PositionCondition = ImGuiCond.Always;
+            }
         }
 
         public override bool DrawConditions()
@@ -68,6 +79,19 @@ namespace Wholist.UserInterface.Windows.NearbyPlayers
             {
                 DrawSearchBar(ref this.logic.SearchText);
                 DrawTotalPlayers(playersToDraw.Count);
+            }
+
+            // Set the window position if specified, continuously when the settings window is open
+            Services.WindowManager.WindowingSystem.TryGetWindow<SettingsWindow>(out var settingsWindow);
+            if (settingsWindow.IsFocused)
+            {
+                if (NearbyPlayersLogic.Configuration.NearbyPlayers.SetWindowPosition)
+                {
+                    this.Position = new Vector2(
+                        NearbyPlayersLogic.Configuration.NearbyPlayers.WindowPositionX,
+                        NearbyPlayersLogic.Configuration.NearbyPlayers.WindowPositionY
+                    );
+                }
             }
         }
 

--- a/Wholist/UserInterface/Windows/Settings/TableParts/Sidebar/NearbyPlayersTab.cs
+++ b/Wholist/UserInterface/Windows/Settings/TableParts/Sidebar/NearbyPlayersTab.cs
@@ -1,3 +1,4 @@
+using ImGuiNET;
 using Sirensong.UserInterface;
 using Wholist.Resources.Localization;
 using Wholist.UserInterface.Windows.Settings.Components;
@@ -35,6 +36,33 @@ namespace Wholist.UserInterface.Windows.Settings.TableParts.Sidebar
             Checkbox.Draw(Strings.UserInterface_Settings_NearbyPlayers_HideInCombat, Strings.UserInterface_Settings_NearbyPlayers_HideInCombat_Description, ref SettingsLogic.Configuration.NearbyPlayers.HideInCombat);
             Checkbox.Draw(Strings.UserInterface_Settings_NearbyPlayers_HideInInstance, Strings.UserInterface_Settings_NearbyPlayers_HideInInstance_Description, ref SettingsLogic.Configuration.NearbyPlayers.HideInInstance);
             Checkbox.Draw(Strings.UserInterface_Settings_NearbyPlayers_LockPosition, Strings.UserInterface_Settings_NearbyPlayers_LockPosition_Description, ref SettingsLogic.Configuration.NearbyPlayers.LockPosition);
+            if (SettingsLogic.Configuration.NearbyPlayers.LockPosition)
+            {
+                ImGui.Indent();
+                Checkbox.Draw(Strings.UserInterface_Settings_NearbyPlayers_SpecifiedPosition, Strings.UserInterface_Settings_NearbyPlayers_SpecifiedPosition_Description, ref SettingsLogic.Configuration.NearbyPlayers.SetWindowPosition);
+
+                if (SettingsLogic.Configuration.NearbyPlayers.SetWindowPosition)
+                {
+                    ImGui.Indent();
+                    Slider.Draw(
+                        Strings.UserInterface_Settings_NearbyPlayers_WindowPositionX,
+                        Strings.UserInterface_Settings_NearbyPlayers_WindowPositionX_Description,
+                        ref SettingsLogic.Configuration.NearbyPlayers.WindowPositionX,
+                        0 - 200,
+                        (int)ImGui.GetIO().DisplaySize.X + 200
+                        );
+                    Slider.Draw(
+                        Strings.UserInterface_Settings_NearbyPlayers_WindowPositionY,
+                        Strings.UserInterface_Settings_NearbyPlayers_WindowPositionY_Description,
+                        ref SettingsLogic.Configuration.NearbyPlayers.WindowPositionY,
+                        0 - 200,
+                        (int)ImGui.GetIO().DisplaySize.Y + 200
+                        );
+                    ImGui.Unindent();
+                }
+
+                ImGui.Unindent();
+            }
             Checkbox.Draw(Strings.UserInterface_Settings_NearbyPlayers_LockSize, Strings.UserInterface_Settings_NearbyPlayers_LockSize_Description, ref SettingsLogic.Configuration.NearbyPlayers.LockSize);
         }
 


### PR DESCRIPTION
This is a Proof of Concept for a set window position setting addition. For one, it's a nice setting to have an exact position the window will always show at, but the focus was a setting that would result in the nearby players window not moving when the `/xldev` menu is shown, which this achieves.

This is in response to [this reply](https://discord.com/channels/581875019861328007/1058617511907696650/1176815718331854868) to my feedback.

As this is a POC, I don't actually recommend this be merged alone, or at least not without follow-up, but this does prevent the window from moving when the dev menu is shown and does add a minor feature.
I marked this as allowing edits to my branch in the case that that would be a cleaner way to build upon this.
This could also be a feature without an associated setting, which I think most users may prefer, but I have not gotten into drag events or immediately notice any, which is where I assume you would implement that, so I left that alone.

I also assume that this setting could be moved under a different setting that might make more sense, I did not give a lot of thought to that, and now seeing my image here it could certainly make more sense under other settings.

Here are the settings I added, and showing that the dev menu does not affect them:
![showing the new settings, and that the window has not moved after the dev menu was drawn](https://github.com/Blooym/Wholist/assets/1582821/9968dea2-559b-4157-8019-c2596b1f9452)

### Changes
<!-- Describe your commits and what they change. -->

- Added option to settings menu to display the window at a fixed position.
- Added option to settings menu for the window position.
- Added localization strings for the text for those settings.
- Added conditional position drawing to the nearby player window.
- Added conditional continuous position drawing to the nearby player window when settings are being modified.

<!-- If this pull request is related to any issues, please tag them below. -->

### Should be changed, but wasn't

- I Excluded the `Strings.Designer.cs` regeneration as it needlessly changed the style of everything.
- I am unfamiliar with this localization system, I assume that these strings should be added elsewhere as well.
- I am unfamiliar with Siren GUI, I assume that the Settings I added could be done better.
