### PR TITLE
make low level filter optional

### DIFF
--- a/Wholist/Configuration/PluginConfiguration.cs
+++ b/Wholist/Configuration/PluginConfiguration.cs
@@ -92,6 +92,11 @@ namespace Wholist.Configuration
             public bool FilterBlockedPlayers = true;
 
             /// <summary>
+            ///     Whether to hide low level characters.
+            /// </summary>
+            public bool FilterLowLevel = true;
+
+            /// <summary>
             ///     The region to perform a lodestone player search lookup on.
             /// </summary>
             public LodestoneSearchRegion LodestonePlayerSearchRegion = LodestoneSearchRegion.Europe;

--- a/Wholist/Game/PlayerManager.cs
+++ b/Wholist/Game/PlayerManager.cs
@@ -27,7 +27,7 @@ namespace Wholist.Game
         /// <param name="prioritizeKnownPlayers">Whether to prioritize known players.</param>
         /// <param name="filterAfk">Whether to filter out AFK players.</param>
         /// <returns></returns>
-        internal static unsafe List<PlayerInfoSlim> GetNearbyPlayersSlim(int maxPlayers = 100, bool filterAfk = false, bool prioritizeKnownPlayers = false)
+        internal static unsafe List<PlayerInfoSlim> GetNearbyPlayersSlim(int maxPlayers = 100, bool filterAfk = false, bool prioritizeKnownPlayers = false, bool filterLowLevel = false)
         {
             var nearbyPlayers = new List<PlayerInfoSlim>();
 
@@ -47,7 +47,7 @@ namespace Wholist.Game
                     continue;
                 }
 
-                if (player.Level <= 3)
+                if (filterLowLevel && player.Level <= 3)
                 {
                     continue;
                 }

--- a/Wholist/Resources/Localization/Strings.resx
+++ b/Wholist/Resources/Localization/Strings.resx
@@ -313,4 +313,11 @@
     xml:space="preserve">
     <value>Remove blocked players from the nearby players list.</value>
   </data>
+  <data name="UserInterface_Settings_NearbyPlayers_FilterLowLevelCharacters" xml:space="preserve">
+    <value>Hide low level characters</value>
+  </data>
+  <data name="UserInterface_Settings_NearbyPlayers_FilterLowLevelCharacters_Description"
+        xml:space="preserve">
+    <value>Remove characters level 3 and below from the nearby players list.</value>
+  </data>
 </root>

--- a/Wholist/UserInterface/Windows/NearbyPlayers/NearbyPlayers.logic.cs
+++ b/Wholist/UserInterface/Windows/NearbyPlayers/NearbyPlayers.logic.cs
@@ -74,7 +74,8 @@ namespace Wholist.UserInterface.Windows.NearbyPlayers
             var nearbyPlayers = PlayerManager.GetNearbyPlayersSlim(
                 Services.Configuration.NearbyPlayers.MaxPlayersToShow,
                 Services.Configuration.NearbyPlayers.FilterAfk,
-                Services.Configuration.NearbyPlayers.PrioritizeKnown);
+                Services.Configuration.NearbyPlayers.PrioritizeKnown,
+                Services.Configuration.NearbyPlayers.FilterLowLevel);
 
             foreach (var player in nearbyPlayers)
             {

--- a/Wholist/UserInterface/Windows/Settings/TableParts/Sidebar/BehaviourTab.cs
+++ b/Wholist/UserInterface/Windows/Settings/TableParts/Sidebar/BehaviourTab.cs
@@ -11,6 +11,7 @@ namespace Wholist.UserInterface.Windows.Settings.TableParts.Sidebar
             Checkbox.Draw(Strings.UserInterface_Settings_NearbyPlayers_PrioritizeKnown, Strings.UserInterface_Settings_NearbyPlayers_PrioritizeKnown_Description, ref Services.Configuration.NearbyPlayers.PrioritizeKnown);
             Checkbox.Draw(Strings.UserInterface_Settings_NearbyPlayers_FilterAFKPlayers, Strings.UserInterface_Settings_NearbyPlayers_FilterAFKPlayers_Description, ref Services.Configuration.NearbyPlayers.FilterAfk);
             Checkbox.Draw(Strings.UserInterface_Settings_NearbyPlayers_FilterBlockedPlayers, Strings.UserInterface_Settings_NearbyPlayers_FilterBlockedPlayers_Description, ref Services.Configuration.NearbyPlayers.FilterBlockedPlayers);
+            Checkbox.Draw(Strings.UserInterface_Settings_NearbyPlayers_FilterLowLevelCharacters, Strings.UserInterface_Settings_NearbyPlayers_FilterLowLevelCharacters_Description, ref Services.Configuration.NearbyPlayers.FilterLowLevel);
             Slider.Draw(Strings.UserInterface_Settings_NearbyPlayers_MaxPlayers, Strings.UserInterface_Settings_NearbyPlayers_MaxPlayers_Description, ref Services.Configuration.NearbyPlayers.MaxPlayersToShow, 5, 100);
             EnumCombo.Draw(Strings.UserInterface_Settings_NearbyPlayers_LodestoneRegion, Strings.UserInterface_Settings_NearbyPlayers_LodestoneRegion_Description, ref Services.Configuration.NearbyPlayers.LodestonePlayerSearchRegion);
         }


### PR DESCRIPTION
Adds an option to toggle the removal of level <= 3 characters.

No more baby alts jump scaring me while I do weird plugin testing